### PR TITLE
Add Domain to AWS::EC2::EIP

### DIFF
--- a/starter/c3-app.yml
+++ b/starter/c3-app.yml
@@ -113,6 +113,7 @@ Resources:
   AppEIP:
     Type: AWS::EC2::EIP
     Properties:
+      Domain: vpc
       InstanceId: !Ref RecipeWebServiceInstance
 
   AppLoadBalancer:


### PR DESCRIPTION
Without the domain, the creation is Rolling back.